### PR TITLE
feat(kubernetes): implement Kubernetes deployment manifests

### DIFF
--- a/helm/ecap/Chart.yaml
+++ b/helm/ecap/Chart.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: v2
+name: ecap
+description: A Helm chart for the E-Commerce Analytics Platform
+type: application
+version: 0.1.0
+appVersion: "1.0.0"
+dependencies:
+  - name: api
+    version: 0.1.0
+    repository: "file://charts/api"
+  - name: streaming-consumer
+    version: 0.1.0
+    repository: "file://charts/streaming-consumer"
+  - name: transaction-producer
+    version: 0.1.0
+    repository: "file://charts/transaction-producer"
+  - name: user-behavior-producer
+    version: 0.1.0
+    repository: "file://charts/user-behavior-producer"
+  - name: dashboard
+    version: 0.1.0
+    repository: "file://charts/dashboard"
+  - name: spark-master
+    version: 0.1.0
+    repository: "file://charts/spark-master"
+  - name: spark-worker
+    version: 0.1.0
+    repository: "file://charts/spark-worker"
+  - name: postgresql
+    version: 0.1.0
+    repository: "file://charts/postgresql"
+  - name: redis
+    version: 0.1.0
+    repository: "file://charts/redis"
+  - name: minio
+    version: 0.1.0
+    repository: "file://charts/minio"
+  - name: kafka
+    version: 0.1.0
+    repository: "file://charts/kafka"
+  - name: zookeeper
+    version: 0.1.0
+    repository: "file://charts/zookeeper"

--- a/helm/ecap/README.md
+++ b/helm/ecap/README.md
@@ -1,0 +1,127 @@
+# E-Commerce Analytics Platform Helm Chart
+
+This chart deploys the E-Commerce Analytics Platform (ECAP) to a Kubernetes cluster.
+
+## Prerequisites
+
+- Kubernetes 1.19+
+- Helm 3.0+
+
+## Installation
+
+1. Add the ECAP Helm repository:
+
+   ```bash
+   helm repo add ecap ./helm/ecap
+   helm repo update
+   ```
+
+2. Install the chart:
+
+   ```bash
+   helm install my-ecap ecap/ecap
+   ```
+
+## Configuration
+
+The following table lists the configurable parameters of the ECAP chart and their default values.
+
+| Parameter | Description | Default |
+|---|---|---|
+| `global.environment` | Deployment environment (e.g., `development`, `production`) | `development` |
+| `global.imagePullPolicy` | Image pull policy for all containers | `IfNotPresent` |
+| `api.replicaCount` | Number of API service replicas | `1` |
+| `api.image.repository` | API service image repository | `ecap-api` |
+| `api.image.tag` | API service image tag | `latest` |
+| `api.service.type` | API service type | `ClusterIP` |
+| `api.service.port` | API service port | `8000` |
+| `streamingConsumer.replicaCount` | Number of streaming consumer replicas | `1` |
+| `streamingConsumer.image.repository` | Streaming consumer image repository | `ecap-streaming-consumer` |
+| `streamingConsumer.image.tag` | Streaming consumer image tag | `latest` |
+| `streamingConsumer.spark.master` | Spark master URL for streaming consumer | `spark://spark-master:7077` |
+| `streamingConsumer.spark.driverMemory` | Spark driver memory for streaming consumer | `1g` |
+| `streamingConsumer.spark.executorMemory` | Spark executor memory for streaming consumer | `1g` |
+| `streamingConsumer.spark.executorCores` | Spark executor cores for streaming consumer | `1` |
+| `transactionProducer.replicaCount` | Number of transaction producer replicas | `1` |
+| `transactionProducer.image.repository` | Transaction producer image repository | `ecap-transaction-producer` |
+| `transactionProducer.image.tag` | Transaction producer image tag | `latest` |
+| `transactionProducer.kafka.bootstrapServers` | Kafka bootstrap servers for transaction producer | `kafka:9092` |
+| `transactionProducer.kafka.topic` | Kafka topic for transaction producer | `transactions` |
+| `userBehaviorProducer.replicaCount` | Number of user behavior producer replicas | `1` |
+| `userBehaviorProducer.image.repository` | User behavior producer image repository | `ecap-user-behavior-producer` |
+| `userBehaviorProducer.image.tag` | User behavior producer image tag | `latest` |
+| `userBehaviorProducer.kafka.bootstrapServers` | Kafka bootstrap servers for user behavior producer | `kafka:9092` |
+| `userBehaviorProducer.kafka.topic` | Kafka topic for user behavior producer | `user-events` |
+| `dashboard.replicaCount` | Number of dashboard replicas | `1` |
+| `dashboard.image.repository` | Dashboard image repository | `ecap-dashboard` |
+| `dashboard.image.tag` | Dashboard image tag | `latest` |
+| `dashboard.service.type` | Dashboard service type | `ClusterIP` |
+| `dashboard.service.port` | Dashboard service port | `8501` |
+| `sparkMaster.replicaCount` | Number of Spark master replicas | `1` |
+| `sparkMaster.image.repository` | Spark master image repository | `bitnami/spark` |
+| `sparkMaster.image.tag` | Spark master image tag | `3.4.1` |
+| `sparkMaster.service.type` | Spark master service type | `ClusterIP` |
+| `sparkMaster.service.ports.web.port` | Spark master web UI port | `8080` |
+| `sparkMaster.service.ports.spark.port` | Spark master RPC port | `7077` |
+| `sparkWorker.replicaCount` | Number of Spark worker replicas | `1` |
+| `sparkWorker.image.repository` | Spark worker image repository | `bitnami/spark` |
+| `sparkWorker.image.tag` | Spark worker image tag | `3.4.1` |
+| `sparkWorker.spark.masterUrl` | Spark master URL for workers | `spark://spark-master:7077` |
+| `sparkWorker.spark.workerMemory` | Spark worker memory | `2G` |
+| `sparkWorker.spark.workerCores` | Spark worker cores | `2` |
+| `postgresql.image.repository` | PostgreSQL image repository | `postgres` |
+| `postgresql.image.tag` | PostgreSQL image tag | `15-alpine` |
+| `postgresql.environment.POSTGRES_DB` | PostgreSQL database name | `ecommerce_analytics` |
+| `postgresql.environment.POSTGRES_USER` | PostgreSQL user | `analytics_user` |
+| `postgresql.environment.POSTGRES_PASSWORD` | PostgreSQL password | `dev_password` |
+| `postgresql.service.type` | PostgreSQL service type | `ClusterIP` |
+| `postgresql.service.port` | PostgreSQL service port | `5432` |
+| `postgresql.persistence.enabled` | Enable PostgreSQL persistence | `true` |
+| `postgresql.persistence.size` | PostgreSQL persistence volume size | `1Gi` |
+| `redis.image.repository` | Redis image repository | `redis` |
+| `redis.image.tag` | Redis image tag | `7-alpine` |
+| `redis.service.type` | Redis service type | `ClusterIP` |
+| `redis.service.port` | Redis service port | `6379` |
+| `redis.persistence.enabled` | Enable Redis persistence | `true` |
+| `redis.persistence.size` | Redis persistence volume size | `1Gi` |
+| `minio.image.repository` | MinIO image repository | `minio/minio` |
+| `minio.image.tag` | MinIO image tag | `latest` |
+| `minio.environment.MINIO_ROOT_USER` | MinIO root user | `minioadmin` |
+| `minio.environment.MINIO_ROOT_PASSWORD` | MinIO root password | `minioadmin` |
+| `minio.service.type` | MinIO service type | `ClusterIP` |
+| `minio.service.port` | MinIO API port | `9000` |
+| `minio.service.consolePort` | MinIO console port | `9001` |
+| `minio.persistence.enabled` | Enable MinIO persistence | `true` |
+| `minio.persistence.size` | MinIO persistence volume size | `10Gi` |
+| `kafka.image.repository` | Kafka image repository | `confluentinc/cp-kafka` |
+| `kafka.image.tag` | Kafka image tag | `7.4.0` |
+| `kafka.kafka.brokerId` | Kafka broker ID | `1` |
+| `kafka.kafka.advertisedListeners` | Kafka advertised listeners | `PLAINTEXT://kafka:9092` |
+| `kafka.kafka.offsetsTopicReplicationFactor` | Kafka offsets topic replication factor | `1` |
+| `kafka.kafka.groupInitialRebalanceDelayMs` | Kafka group initial rebalance delay | `0` |
+| `kafka.kafka.jmxPort` | Kafka JMX port | `9997` |
+| `kafka.service.type` | Kafka service type | `ClusterIP` |
+| `kafka.service.port` | Kafka service port | `9092` |
+| `kafka.persistence.enabled` | Enable Kafka persistence | `true` |
+| `kafka.persistence.size` | Kafka persistence volume size | `10Gi` |
+| `zookeeper.image.repository` | Zookeeper image repository | `confluentinc/cp-zookeeper` |
+| `zookeeper.image.tag` | Zookeeper image tag | `7.4.0` |
+| `zookeeper.clientPort` | Zookeeper client port | `2181` |
+| `zookeeper.tickTime` | Zookeeper tick time | `2000` |
+| `zookeeper.persistence.enabled` | Enable Zookeeper persistence | `true` |
+| `zookeeper.persistence.dataSize` | Zookeeper data volume size | `1Gi` |
+| `zookeeper.persistence.logSize` | Zookeeper log volume size | `1Gi` |
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided via the `-f` flag.
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-ecap` deployment:
+
+```bash
+helm uninstall my-ecap
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.

--- a/helm/ecap/charts/api/Chart.yaml
+++ b/helm/ecap/charts/api/Chart.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v2
+name: api
+description: A Helm chart for the ECAP API service
+type: application
+version: 0.1.0
+appVersion: "1.0.0"

--- a/helm/ecap/charts/api/templates/deployment.yaml
+++ b/helm/ecap/charts/api/templates/deployment.yaml
@@ -1,0 +1,26 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{include "ecap.fullname" .}}
+  labels:
+    {{- include "ecap.labels" . | nindent 4}}
+spec:
+  replicas: {{.Values.replicaCount}}
+  selector:
+    matchLabels:
+      {{- include "ecap.selectorLabels" . | nindent 6}}
+  template:
+    metadata:
+      labels:
+        {{- include "ecap.selectorLabels" . | nindent 8}}
+    spec:
+      containers:
+        - name: {{.Chart.Name}}
+          image: "{{.Values.image.repository}}:{{.Values.image.tag | default .Chart.AppVersion}}"
+          imagePullPolicy: {{.Values.image.pullPolicy}}
+          ports:
+            - name: http
+              containerPort: {{.Values.service.port}}
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.resources | nindent 12}}

--- a/helm/ecap/charts/api/templates/service.yaml
+++ b/helm/ecap/charts/api/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{include "ecap.fullname" .}}
+  labels:
+    {{- include "ecap.labels" . | nindent 4}}
+spec:
+  type: {{.Values.service.type}}
+  ports:
+    - port: {{.Values.service.port}}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "ecap.selectorLabels" . | nindent 4}}

--- a/helm/ecap/charts/api/values.yaml
+++ b/helm/ecap/charts/api/values.yaml
@@ -1,0 +1,23 @@
+---
+replicaCount: 1
+
+image:
+  repository: ecap-api
+  pullPolicy: IfNotPresent
+  tag: "latest"
+
+service:
+  type: ClusterIP
+  port: 8000
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the
+  # following lines, adjust them as necessary, and remove the curly braces.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi

--- a/helm/ecap/charts/dashboard/Chart.yaml
+++ b/helm/ecap/charts/dashboard/Chart.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v2
+name: dashboard
+description: A Helm chart for the ECAP Streamlit dashboard
+type: application
+version: 0.1.0
+appVersion: "1.0.0"

--- a/helm/ecap/charts/dashboard/templates/deployment.yaml
+++ b/helm/ecap/charts/dashboard/templates/deployment.yaml
@@ -1,0 +1,26 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{include "ecap.fullname" .}}
+  labels:
+    {{- include "ecap.labels" . | nindent 4}}
+spec:
+  replicas: {{.Values.replicaCount}}
+  selector:
+    matchLabels:
+      {{- include "ecap.selectorLabels" . | nindent 6}}
+  template:
+    metadata:
+      labels:
+        {{- include "ecap.selectorLabels" . | nindent 8}}
+    spec:
+      containers:
+        - name: {{.Chart.Name}}
+          image: "{{.Values.image.repository}}:{{.Values.image.tag | default .Chart.AppVersion}}"
+          imagePullPolicy: {{.Values.image.pullPolicy}}
+          ports:
+            - name: http
+              containerPort: {{.Values.service.port}}
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.resources | nindent 12}}

--- a/helm/ecap/charts/dashboard/templates/service.yaml
+++ b/helm/ecap/charts/dashboard/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{include "ecap.fullname" .}}
+  labels:
+    {{- include "ecap.labels" . | nindent 4}}
+spec:
+  type: {{.Values.service.type}}
+  ports:
+    - port: {{.Values.service.port}}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "ecap.selectorLabels" . | nindent 4}}

--- a/helm/ecap/charts/dashboard/values.yaml
+++ b/helm/ecap/charts/dashboard/values.yaml
@@ -1,0 +1,13 @@
+---
+replicaCount: 1
+
+image:
+  repository: ecap-dashboard
+  pullPolicy: IfNotPresent
+  tag: "latest"
+
+service:
+  type: ClusterIP
+  port: 8501
+
+resources: {}

--- a/helm/ecap/charts/kafka/Chart.yaml
+++ b/helm/ecap/charts/kafka/Chart.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v2
+name: kafka
+description: A Helm chart for Apache Kafka
+type: application
+version: 0.1.0
+appVersion: "7.4.0"

--- a/helm/ecap/charts/kafka/templates/deployment.yaml
+++ b/helm/ecap/charts/kafka/templates/deployment.yaml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{include "ecap.fullname" .}}
+  labels:
+    {{- include "ecap.labels" . | nindent 4}}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "ecap.selectorLabels" . | nindent 6}}
+  template:
+    metadata:
+      labels:
+        {{- include "ecap.selectorLabels" . | nindent 8}}
+    spec:
+      containers:
+        - name: {{.Chart.Name}}
+          image: "{{.Values.image.repository}}:{{.Values.image.tag | default .Chart.AppVersion}}"
+          imagePullPolicy: {{.Values.image.pullPolicy}}
+          env:
+            - name: KAFKA_BROKER_ID
+              value: {{.Values.kafka.brokerId | quote}}
+            - name: KAFKA_ZOOKEEPER_CONNECT
+              value: {{include "ecap.fullname" .}}-zookeeper:{{.Values.zookeeper.clientPort}}
+            - name: KAFKA_ADVERTISED_LISTENERS
+              value: {{.Values.kafka.advertisedListeners}}
+            - name: KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR
+              value: {{.Values.kafka.offsetsTopicReplicationFactor | quote}}
+            - name: KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS
+              value: {{.Values.kafka.groupInitialRebalanceDelayMs | quote}}
+            - name: KAFKA_JMX_PORT
+              value: {{.Values.kafka.jmxPort | quote}}
+          ports:
+            - name: kafka
+              containerPort: {{.Values.service.port}}
+              protocol: TCP
+            - name: jmx
+              containerPort: {{.Values.kafka.jmxPort}}
+              protocol: TCP
+          volumeMounts:
+            - name: kafka-data
+              mountPath: /var/lib/kafka/data
+          resources:
+            {{- toYaml .Values.resources | nindent 12}}
+      volumes:
+        - name: kafka-data
+          persistentVolumeClaim:
+            claimName: {{include "ecap.fullname" .}}-data

--- a/helm/ecap/charts/kafka/templates/persistentvolumeclaim.yaml
+++ b/helm/ecap/charts/kafka/templates/persistentvolumeclaim.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "ecap.fullname" . }}-data
+  labels:
+    {{- include "ecap.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{.Values.persistence.size}}

--- a/helm/ecap/charts/kafka/templates/service.yaml
+++ b/helm/ecap/charts/kafka/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{include "ecap.fullname" .}}
+  labels:
+    {{- include "ecap.labels" . | nindent 4}}
+spec:
+  type: {{.Values.service.type}}
+  ports:
+    - port: {{.Values.service.port}}
+      targetPort: kafka
+      protocol: TCP
+      name: kafka
+    - port: {{.Values.kafka.jmxPort}}
+      targetPort: jmx
+      protocol: TCP
+      name: jmx
+  selector:
+    {{- include "ecap.selectorLabels" . | nindent 4}}

--- a/helm/ecap/charts/kafka/templates/zookeeper-deployment.yaml
+++ b/helm/ecap/charts/kafka/templates/zookeeper-deployment.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{include "ecap.fullname" .}}-zookeeper
+  labels:
+    {{- include "ecap.labels" . | nindent 4}}
+    app.kubernetes.io/component: zookeeper
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "ecap.selectorLabels" . | nindent 6}}
+      app.kubernetes.io/component: zookeeper
+  template:
+    metadata:
+      labels:
+        {{- include "ecap.selectorLabels" . | nindent 8}}
+        app.kubernetes.io/component: zookeeper
+    spec:
+      containers:
+        - name: zookeeper
+          image: "{{.Values.zookeeper.image.repository}}:{{.Values.zookeeper.image.tag}}"
+          imagePullPolicy: {{.Values.zookeeper.image.pullPolicy}}
+          env:
+            - name: ZOOKEEPER_CLIENT_PORT
+              value: {{.Values.zookeeper.clientPort | quote}}
+            - name: ZOOKEEPER_TICK_TIME
+              value: {{.Values.zookeeper.tickTime | quote}}
+          ports:
+            - name: client
+              containerPort: {{.Values.zookeeper.clientPort}}
+              protocol: TCP
+          volumeMounts:
+            - name: zookeeper-data
+              mountPath: /var/lib/zookeeper/data
+            - name: zookeeper-logs
+              mountPath: /var/lib/zookeeper/log
+          resources:
+            {{- toYaml .Values.resources | nindent 12}}
+      volumes:
+        - name: zookeeper-data
+          persistentVolumeClaim:
+            claimName: {{include "ecap.fullname" .}}-zookeeper-data
+        - name: zookeeper-logs
+          persistentVolumeClaim:
+            claimName: {{include "ecap.fullname" .}}-zookeeper-logs

--- a/helm/ecap/charts/kafka/templates/zookeeper-persistentvolumeclaim.yaml
+++ b/helm/ecap/charts/kafka/templates/zookeeper-persistentvolumeclaim.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "ecap.fullname" . }}-zookeeper-data
+  labels:
+    {{- include "ecap.labels" . | nindent 4 }}
+    app.kubernetes.io/component: zookeeper
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{.Values.persistence.dataSize}}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "ecap.fullname" . }}-zookeeper-logs
+  labels:
+    {{- include "ecap.labels" . | nindent 4 }}
+    app.kubernetes.io/component: zookeeper
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{.Values.persistence.logSize}}

--- a/helm/ecap/charts/kafka/templates/zookeeper-service.yaml
+++ b/helm/ecap/charts/kafka/templates/zookeeper-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{include "ecap.fullname" .}}-zookeeper
+  labels:
+    {{- include "ecap.labels" . | nindent 4}}
+    app.kubernetes.io/component: zookeeper
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{.Values.zookeeper.clientPort}}
+      targetPort: client
+      protocol: TCP
+      name: client
+  selector:
+    {{- include "ecap.selectorLabels" . | nindent 4}}
+    app.kubernetes.io/component: zookeeper

--- a/helm/ecap/charts/kafka/values.yaml
+++ b/helm/ecap/charts/kafka/values.yaml
@@ -1,0 +1,30 @@
+---
+image:
+  repository: confluentinc/cp-kafka
+  pullPolicy: IfNotPresent
+  tag: "7.4.0"
+
+zookeeper:
+  image:
+    repository: confluentinc/cp-zookeeper
+    pullPolicy: IfNotPresent
+    tag: "7.4.0"
+  clientPort: 2181
+  tickTime: 2000
+
+kafka:
+  brokerId: 1
+  advertisedListeners: "PLAINTEXT://kafka:9092"
+  offsetsTopicReplicationFactor: 1
+  groupInitialRebalanceDelayMs: 0
+  jmxPort: 9997
+
+service:
+  type: ClusterIP
+  port: 9092
+
+persistence:
+  enabled: true
+  size: 10Gi
+
+resources: {}

--- a/helm/ecap/charts/minio/Chart.yaml
+++ b/helm/ecap/charts/minio/Chart.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v2
+name: minio
+description: A Helm chart for MinIO object storage
+type: application
+version: 0.1.0
+appVersion: "latest"

--- a/helm/ecap/charts/minio/templates/deployment.yaml
+++ b/helm/ecap/charts/minio/templates/deployment.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{include "ecap.fullname" .}}
+  labels:
+    {{- include "ecap.labels" . | nindent 4}}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "ecap.selectorLabels" . | nindent 6}}
+  template:
+    metadata:
+      labels:
+        {{- include "ecap.selectorLabels" . | nindent 8}}
+    spec:
+      containers:
+        - name: {{.Chart.Name}}
+          image: "{{.Values.image.repository}}:{{.Values.image.tag | default .Chart.AppVersion}}"
+          imagePullPolicy: {{.Values.image.pullPolicy}}
+          env:
+            - name: MINIO_ROOT_USER
+              value: {{.Values.environment.MINIO_ROOT_USER}}
+            - name: MINIO_ROOT_PASSWORD
+              value: {{.Values.environment.MINIO_ROOT_PASSWORD}}
+          command: ["minio", "server", "/data", "--console-address", ":{{.Values.service.consolePort}}"]
+          ports:
+            - name: api
+              containerPort: {{.Values.service.port}}
+              protocol: TCP
+            - name: console
+              containerPort: {{.Values.service.consolePort}}
+              protocol: TCP
+          volumeMounts:
+            - name: minio-data
+              mountPath: /data
+          resources:
+            {{- toYaml .Values.resources | nindent 12}}
+      volumes:
+        - name: minio-data
+          persistentVolumeClaim:
+            claimName: {{include "ecap.fullname" .}}-data

--- a/helm/ecap/charts/minio/templates/persistentvolumeclaim.yaml
+++ b/helm/ecap/charts/minio/templates/persistentvolumeclaim.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "ecap.fullname" . }}-data
+  labels:
+    {{- include "ecap.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{.Values.persistence.size}}

--- a/helm/ecap/charts/minio/templates/service.yaml
+++ b/helm/ecap/charts/minio/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{include "ecap.fullname" .}}
+  labels:
+    {{- include "ecap.labels" . | nindent 4}}
+spec:
+  type: {{.Values.service.type}}
+  ports:
+    - port: {{.Values.service.port}}
+      targetPort: api
+      protocol: TCP
+      name: api
+    - port: {{.Values.service.consolePort}}
+      targetPort: console
+      protocol: TCP
+      name: console
+  selector:
+    {{- include "ecap.selectorLabels" . | nindent 4}}

--- a/helm/ecap/charts/minio/values.yaml
+++ b/helm/ecap/charts/minio/values.yaml
@@ -1,0 +1,20 @@
+---
+image:
+  repository: minio/minio
+  pullPolicy: IfNotPresent
+  tag: "latest"
+
+environment:
+  MINIO_ROOT_USER: minioadmin
+  MINIO_ROOT_PASSWORD: minioadmin
+
+service:
+  type: ClusterIP
+  port: 9000
+  consolePort: 9001
+
+persistence:
+  enabled: true
+  size: 10Gi
+
+resources: {}

--- a/helm/ecap/charts/postgresql/Chart.yaml
+++ b/helm/ecap/charts/postgresql/Chart.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v2
+name: postgresql
+description: A Helm chart for PostgreSQL database
+type: application
+version: 0.1.0
+appVersion: "15"

--- a/helm/ecap/charts/postgresql/templates/deployment.yaml
+++ b/helm/ecap/charts/postgresql/templates/deployment.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{include "ecap.fullname" .}}
+  labels:
+    {{- include "ecap.labels" . | nindent 4}}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "ecap.selectorLabels" . | nindent 6}}
+  template:
+    metadata:
+      labels:
+        {{- include "ecap.selectorLabels" . | nindent 8}}
+    spec:
+      containers:
+        - name: {{.Chart.Name}}
+          image: "{{.Values.image.repository}}:{{.Values.image.tag | default .Chart.AppVersion}}"
+          imagePullPolicy: {{.Values.image.pullPolicy}}
+          env:
+            - name: POSTGRES_DB
+              value: {{.Values.environment.POSTGRES_DB}}
+            - name: POSTGRES_USER
+              value: {{.Values.environment.POSTGRES_USER}}
+            - name: POSTGRES_PASSWORD
+              value: {{.Values.environment.POSTGRES_PASSWORD}}
+          ports:
+            - name: postgres
+              containerPort: 5432
+              protocol: TCP
+          volumeMounts:
+            - name: postgres-data
+              mountPath: /var/lib/postgresql/data
+          resources:
+            {{- toYaml .Values.resources | nindent 12}}
+      volumes:
+        - name: postgres-data
+          persistentVolumeClaim:
+            claimName: {{include "ecap.fullname" .}}-data

--- a/helm/ecap/charts/postgresql/templates/persistentvolumeclaim.yaml
+++ b/helm/ecap/charts/postgresql/templates/persistentvolumeclaim.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "ecap.fullname" . }}-data
+  labels:
+    {{- include "ecap.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{.Values.persistence.size}}

--- a/helm/ecap/charts/postgresql/templates/service.yaml
+++ b/helm/ecap/charts/postgresql/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{include "ecap.fullname" .}}
+  labels:
+    {{- include "ecap.labels" . | nindent 4}}
+spec:
+  type: {{.Values.service.type}}
+  ports:
+    - port: {{.Values.service.port}}
+      targetPort: postgres
+      protocol: TCP
+      name: postgres
+  selector:
+    {{- include "ecap.selectorLabels" . | nindent 4}}

--- a/helm/ecap/charts/postgresql/values.yaml
+++ b/helm/ecap/charts/postgresql/values.yaml
@@ -1,0 +1,20 @@
+---
+image:
+  repository: postgres
+  pullPolicy: IfNotPresent
+  tag: "15-alpine"
+
+environment:
+  POSTGRES_DB: ecommerce_analytics
+  POSTGRES_USER: analytics_user
+  POSTGRES_PASSWORD: dev_password
+
+service:
+  type: ClusterIP
+  port: 5432
+
+persistence:
+  enabled: true
+  size: 1Gi
+
+resources: {}

--- a/helm/ecap/charts/redis/Chart.yaml
+++ b/helm/ecap/charts/redis/Chart.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v2
+name: redis
+description: A Helm chart for Redis
+type: application
+version: 0.1.0
+appVersion: "7"

--- a/helm/ecap/charts/redis/templates/deployment.yaml
+++ b/helm/ecap/charts/redis/templates/deployment.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{include "ecap.fullname" .}}
+  labels:
+    {{- include "ecap.labels" . | nindent 4}}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "ecap.selectorLabels" . | nindent 6}}
+  template:
+    metadata:
+      labels:
+        {{- include "ecap.selectorLabels" . | nindent 8}}
+    spec:
+      containers:
+        - name: {{.Chart.Name}}
+          image: "{{.Values.image.repository}}:{{.Values.image.tag | default .Chart.AppVersion}}"
+          imagePullPolicy: {{.Values.image.pullPolicy}}
+          ports:
+            - name: redis
+              containerPort: 6379
+              protocol: TCP
+          volumeMounts:
+            - name: redis-data
+              mountPath: /data
+          resources:
+            {{- toYaml .Values.resources | nindent 12}}
+      volumes:
+        - name: redis-data
+          persistentVolumeClaim:
+            claimName: {{include "ecap.fullname" .}}-data

--- a/helm/ecap/charts/redis/templates/persistentvolumeclaim.yaml
+++ b/helm/ecap/charts/redis/templates/persistentvolumeclaim.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "ecap.fullname" . }}-data
+  labels:
+    {{- include "ecap.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{.Values.persistence.size}}

--- a/helm/ecap/charts/redis/templates/service.yaml
+++ b/helm/ecap/charts/redis/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{include "ecap.fullname" .}}
+  labels:
+    {{- include "ecap.labels" . | nindent 4}}
+spec:
+  type: {{.Values.service.type}}
+  ports:
+    - port: {{.Values.service.port}}
+      targetPort: redis
+      protocol: TCP
+      name: redis
+  selector:
+    {{- include "ecap.selectorLabels" . | nindent 4}}

--- a/helm/ecap/charts/redis/values.yaml
+++ b/helm/ecap/charts/redis/values.yaml
@@ -1,0 +1,15 @@
+---
+image:
+  repository: redis
+  pullPolicy: IfNotPresent
+  tag: "7-alpine"
+
+service:
+  type: ClusterIP
+  port: 6379
+
+persistence:
+  enabled: true
+  size: 1Gi
+
+resources: {}

--- a/helm/ecap/charts/spark-master/Chart.yaml
+++ b/helm/ecap/charts/spark-master/Chart.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v2
+name: spark-master
+description: A Helm chart for the Spark Master service
+type: application
+version: 0.1.0
+appVersion: "3.4.1"

--- a/helm/ecap/charts/spark-master/templates/deployment.yaml
+++ b/helm/ecap/charts/spark-master/templates/deployment.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{include "ecap.fullname" .}}
+  labels:
+    {{- include "ecap.labels" . | nindent 4}}
+spec:
+  replicas: {{.Values.replicaCount}}
+  selector:
+    matchLabels:
+      {{- include "ecap.selectorLabels" . | nindent 6}}
+  template:
+    metadata:
+      labels:
+        {{- include "ecap.selectorLabels" . | nindent 8}}
+    spec:
+      containers:
+        - name: {{.Chart.Name}}
+          image: "{{.Values.image.repository}}:{{.Values.image.tag | default .Chart.AppVersion}}"
+          imagePullPolicy: {{.Values.image.pullPolicy}}
+          env:
+            - name: SPARK_MODE
+              value: master
+            - name: SPARK_RPC_AUTHENTICATION_ENABLED
+              value: "no"
+            - name: SPARK_RPC_ENCRYPTION_ENABLED
+              value: "no"
+            - name: SPARK_LOCAL_STORAGE_ENCRYPTION_ENABLED
+              value: "no"
+            - name: SPARK_SSL_ENABLED
+              value: "no"
+          ports:
+            - name: web
+              containerPort: 8080
+              protocol: TCP
+            - name: spark
+              containerPort: 7077
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.resources | nindent 12}}

--- a/helm/ecap/charts/spark-master/templates/service.yaml
+++ b/helm/ecap/charts/spark-master/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{include "ecap.fullname" .}}
+  labels:
+    {{- include "ecap.labels" . | nindent 4}}
+spec:
+  type: {{.Values.service.type}}
+  ports:
+    - port: {{.Values.service.ports.web.port}}
+      targetPort: {{.Values.service.ports.web.targetPort}}
+      protocol: TCP
+      name: {{.Values.service.ports.web.name}}
+    - port: {{.Values.service.ports.spark.port}}
+      targetPort: {{.Values.service.ports.spark.targetPort}}
+      protocol: TCP
+      name: {{.Values.service.ports.spark.name}}
+  selector:
+    {{- include "ecap.selectorLabels" . | nindent 4}}

--- a/helm/ecap/charts/spark-master/values.yaml
+++ b/helm/ecap/charts/spark-master/values.yaml
@@ -1,0 +1,21 @@
+---
+replicaCount: 1
+
+image:
+  repository: bitnami/spark
+  pullPolicy: IfNotPresent
+  tag: "3.4.1"
+
+service:
+  type: ClusterIP
+  ports:
+    web:
+      port: 8080
+      targetPort: 8080
+      name: web
+    spark:
+      port: 7077
+      targetPort: 7077
+      name: spark
+
+resources: {}

--- a/helm/ecap/charts/spark-worker/Chart.yaml
+++ b/helm/ecap/charts/spark-worker/Chart.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v2
+name: spark-worker
+description: A Helm chart for the Spark Worker service
+type: application
+version: 0.1.0
+appVersion: "3.4.1"

--- a/helm/ecap/charts/spark-worker/templates/deployment.yaml
+++ b/helm/ecap/charts/spark-worker/templates/deployment.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{include "ecap.fullname" .}}
+  labels:
+    {{- include "ecap.labels" . | nindent 4}}
+spec:
+  replicas: {{.Values.replicaCount}}
+  selector:
+    matchLabels:
+      {{- include "ecap.selectorLabels" . | nindent 6}}
+  template:
+    metadata:
+      labels:
+        {{- include "ecap.selectorLabels" . | nindent 8}}
+    spec:
+      containers:
+        - name: {{.Chart.Name}}
+          image: "{{.Values.image.repository}}:{{.Values.image.tag | default .Chart.AppVersion}}"
+          imagePullPolicy: {{.Values.image.pullPolicy}}
+          env:
+            - name: SPARK_MODE
+              value: worker
+            - name: SPARK_MASTER_URL
+              value: {{.Values.spark.masterUrl}}
+            - name: SPARK_WORKER_MEMORY
+              value: {{.Values.spark.workerMemory}}
+            - name: SPARK_WORKER_CORES
+              value: {{.Values.spark.workerCores | quote}}
+          resources:
+            {{- toYaml .Values.resources | nindent 12}}

--- a/helm/ecap/charts/spark-worker/values.yaml
+++ b/helm/ecap/charts/spark-worker/values.yaml
@@ -1,0 +1,14 @@
+---
+replicaCount: 1
+
+image:
+  repository: bitnami/spark
+  pullPolicy: IfNotPresent
+  tag: "3.4.1"
+
+spark:
+  masterUrl: "spark://spark-master:7077"
+  workerMemory: "2G"
+  workerCores: 2
+
+resources: {}

--- a/helm/ecap/charts/streaming-consumer/Chart.yaml
+++ b/helm/ecap/charts/streaming-consumer/Chart.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v2
+name: streaming-consumer
+description: A Helm chart for the ECAP streaming consumer service
+type: application
+version: 0.1.0
+appVersion: "1.0.0"

--- a/helm/ecap/charts/streaming-consumer/templates/deployment.yaml
+++ b/helm/ecap/charts/streaming-consumer/templates/deployment.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{include "ecap.fullname" .}}
+  labels:
+    {{- include "ecap.labels" . | nindent 4}}
+spec:
+  replicas: {{.Values.replicaCount}}
+  selector:
+    matchLabels:
+      {{- include "ecap.selectorLabels" . | nindent 6}}
+  template:
+    metadata:
+      labels:
+        {{- include "ecap.selectorLabels" . | nindent 8}}
+    spec:
+      containers:
+        - name: {{.Chart.Name}}
+          image: "{{.Values.image.repository}}:{{.Values.image.tag | default .Chart.AppVersion}}"
+          imagePullPolicy: {{.Values.image.pullPolicy}}
+          env:
+            - name: SPARK_MASTER
+              value: {{.Values.spark.master}}
+            - name: SPARK_DRIVER_MEMORY
+              value: {{.Values.spark.driverMemory}}
+            - name: SPARK_EXECUTOR_MEMORY
+              value: {{.Values.spark.executorMemory}}
+            - name: SPARK_EXECUTOR_CORES
+              value: {{.Values.spark.executorCores | quote}}
+          resources:
+            {{- toYaml .Values.resources | nindent 12}}

--- a/helm/ecap/charts/streaming-consumer/values.yaml
+++ b/helm/ecap/charts/streaming-consumer/values.yaml
@@ -1,0 +1,15 @@
+---
+replicaCount: 1
+
+image:
+  repository: ecap-streaming-consumer
+  pullPolicy: IfNotPresent
+  tag: "latest"
+
+spark:
+  master: "spark://spark-master:7077"
+  driverMemory: "1g"
+  executorMemory: "1g"
+  executorCores: 1
+
+resources: {}

--- a/helm/ecap/charts/transaction-producer/Chart.yaml
+++ b/helm/ecap/charts/transaction-producer/Chart.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v2
+name: transaction-producer
+description: A Helm chart for the ECAP transaction producer service
+type: application
+version: 0.1.0
+appVersion: "1.0.0"

--- a/helm/ecap/charts/transaction-producer/templates/deployment.yaml
+++ b/helm/ecap/charts/transaction-producer/templates/deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{include "ecap.fullname" .}}
+  labels:
+    {{- include "ecap.labels" . | nindent 4}}
+spec:
+  replicas: {{.Values.replicaCount}}
+  selector:
+    matchLabels:
+      {{- include "ecap.selectorLabels" . | nindent 6}}
+  template:
+    metadata:
+      labels:
+        {{- include "ecap.selectorLabels" . | nindent 8}}
+    spec:
+      containers:
+        - name: {{.Chart.Name}}
+          image: "{{.Values.image.repository}}:{{.Values.image.tag | default .Chart.AppVersion}}"
+          imagePullPolicy: {{.Values.image.pullPolicy}}
+          env:
+            - name: KAFKA_BOOTSTRAP_SERVERS
+              value: {{.Values.kafka.bootstrapServers}}
+            - name: KAFKA_TOPIC
+              value: {{.Values.kafka.topic}}
+          resources:
+            {{- toYaml .Values.resources | nindent 12}}

--- a/helm/ecap/charts/transaction-producer/values.yaml
+++ b/helm/ecap/charts/transaction-producer/values.yaml
@@ -1,0 +1,13 @@
+---
+replicaCount: 1
+
+image:
+  repository: ecap-transaction-producer
+  pullPolicy: IfNotPresent
+  tag: "latest"
+
+kafka:
+  bootstrapServers: "kafka:9092"
+  topic: "transactions"
+
+resources: {}

--- a/helm/ecap/charts/user-behavior-producer/Chart.yaml
+++ b/helm/ecap/charts/user-behavior-producer/Chart.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v2
+name: user-behavior-producer
+description: A Helm chart for the ECAP user behavior producer service
+type: application
+version: 0.1.0
+appVersion: "1.0.0"

--- a/helm/ecap/charts/user-behavior-producer/templates/deployment.yaml
+++ b/helm/ecap/charts/user-behavior-producer/templates/deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{include "ecap.fullname" .}}
+  labels:
+    {{- include "ecap.labels" . | nindent 4}}
+spec:
+  replicas: {{.Values.replicaCount}}
+  selector:
+    matchLabels:
+      {{- include "ecap.selectorLabels" . | nindent 6}}
+  template:
+    metadata:
+      labels:
+        {{- include "ecap.selectorLabels" . | nindent 8}}
+    spec:
+      containers:
+        - name: {{.Chart.Name}}
+          image: "{{.Values.image.repository}}:{{.Values.image.tag | default .Chart.AppVersion}}"
+          imagePullPolicy: {{.Values.image.pullPolicy}}
+          env:
+            - name: KAFKA_BOOTSTRAP_SERVERS
+              value: {{.Values.kafka.bootstrapServers}}
+            - name: KAFKA_TOPIC
+              value: {{.Values.kafka.topic}}
+          resources:
+            {{- toYaml .Values.resources | nindent 12}}

--- a/helm/ecap/charts/user-behavior-producer/templates/service.yaml
+++ b/helm/ecap/charts/user-behavior-producer/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{include "ecap.fullname" .}}
+  labels:
+    {{- include "ecap.labels" . | nindent 4}}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "ecap.selectorLabels" . | nindent 4}}

--- a/helm/ecap/charts/user-behavior-producer/values.yaml
+++ b/helm/ecap/charts/user-behavior-producer/values.yaml
@@ -1,0 +1,13 @@
+---
+replicaCount: 1
+
+image:
+  repository: ecap-user-behavior-producer
+  pullPolicy: IfNotPresent
+  tag: "latest"
+
+kafka:
+  bootstrapServers: "kafka:9092"
+  topic: "user-events"
+
+resources: {}

--- a/helm/ecap/charts/zookeeper/Chart.yaml
+++ b/helm/ecap/charts/zookeeper/Chart.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v2
+name: zookeeper
+description: A Helm chart for Apache Zookeeper
+type: application
+version: 0.1.0
+appVersion: "3.8.0"

--- a/helm/ecap/charts/zookeeper/templates/deployment.yaml
+++ b/helm/ecap/charts/zookeeper/templates/deployment.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{include "ecap.fullname" .}}
+  labels:
+    {{- include "ecap.labels" . | nindent 4}}
+    app.kubernetes.io/component: zookeeper
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "ecap.selectorLabels" . | nindent 6}}
+      app.kubernetes.io/component: zookeeper
+  template:
+    metadata:
+      labels:
+        {{- include "ecap.selectorLabels" . | nindent 8}}
+        app.kubernetes.io/component: zookeeper
+    spec:
+      containers:
+        - name: {{.Chart.Name}}
+          image: "{{.Values.image.repository}}:{{.Values.image.tag | default .Chart.AppVersion}}"
+          imagePullPolicy: {{.Values.image.pullPolicy}}
+          env:
+            - name: ZOOKEEPER_CLIENT_PORT
+              value: {{.Values.clientPort | quote}}
+            - name: ZOOKEEPER_TICK_TIME
+              value: {{.Values.tickTime | quote}}
+          ports:
+            - name: client
+              containerPort: {{.Values.clientPort}}
+              protocol: TCP
+          volumeMounts:
+            - name: zookeeper-data
+              mountPath: /var/lib/zookeeper/data
+            - name: zookeeper-logs
+              mountPath: /var/lib/zookeeper/log
+          resources:
+            {{- toYaml .Values.resources | nindent 12}}
+      volumes:
+        - name: zookeeper-data
+          persistentVolumeClaim:
+            claimName: {{include "ecap.fullname" .}}-data
+        - name: zookeeper-logs
+          persistentVolumeClaim:
+            claimName: {{include "ecap.fullname" .}}-logs

--- a/helm/ecap/charts/zookeeper/templates/persistentvolumeclaim.yaml
+++ b/helm/ecap/charts/zookeeper/templates/persistentvolumeclaim.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "ecap.fullname" . }}-data
+  labels:
+    {{- include "ecap.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.persistence.dataSize }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "ecap.fullname" . }}-logs
+  labels:
+    {{- include "ecap.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.persistence.logSize }}

--- a/helm/ecap/charts/zookeeper/templates/service.yaml
+++ b/helm/ecap/charts/zookeeper/templates/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{include "ecap.fullname" .}}
+  labels:
+    {{- include "ecap.labels" . | nindent 4}}
+    app.kubernetes.io/component: zookeeper
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{.Values.clientPort}}
+      targetPort: client
+      protocol: TCP
+      name: client
+  selector:
+    {{- include "ecap.selectorLabels" . | nindent 4}}
+    app.kubernetes.io/component: zookeeper

--- a/helm/ecap/charts/zookeeper/values.yaml
+++ b/helm/ecap/charts/zookeeper/values.yaml
@@ -1,0 +1,15 @@
+---
+image:
+  repository: confluentinc/cp-zookeeper
+  pullPolicy: IfNotPresent
+  tag: "7.4.0"
+
+clientPort: 2181
+tickTime: 2000
+
+persistence:
+  enabled: true
+  dataSize: 1Gi
+  logSize: 1Gi
+
+resources: {}

--- a/helm/ecap/templates/_helpers.tpl
+++ b/helm/ecap/templates/_helpers.tpl
@@ -1,0 +1,51 @@
+{{/*
+Common labels
+*/}}
+{{- define "ecap.labels" -}}
+helm.sh/chart: {{ include "ecap.chart" . }}
+app.kubernetes.io/name: {{ include "ecap.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "ecap.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "ecap.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Chart name
+*/}}
+{{- define "ecap.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "ecap.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this length.
+*/}}
+{{- define "ecap.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/helm/ecap/values.yaml
+++ b/helm/ecap/values.yaml
@@ -1,0 +1,145 @@
+---
+global:
+  environment: development
+  imagePullPolicy: IfNotPresent
+
+api:
+  replicaCount: 1
+  image:
+    repository: ecap-api
+    tag: latest
+  service:
+    type: ClusterIP
+    port: 8000
+
+streamingConsumer:
+  replicaCount: 1
+  image:
+    repository: ecap-streaming-consumer
+    tag: latest
+  spark:
+    master: "spark://spark-master:7077"
+    driverMemory: "1g"
+    executorMemory: "1g"
+    executorCores: 1
+
+transactionProducer:
+  replicaCount: 1
+  image:
+    repository: ecap-transaction-producer
+    tag: latest
+  kafka:
+    bootstrapServers: "kafka:9092"
+    topic: "transactions"
+
+userBehaviorProducer:
+  replicaCount: 1
+  image:
+    repository: ecap-user-behavior-producer
+    tag: latest
+  kafka:
+    bootstrapServers: "kafka:9092"
+    topic: "user-events"
+
+dashboard:
+  replicaCount: 1
+  image:
+    repository: ecap-dashboard
+    tag: latest
+  service:
+    type: ClusterIP
+    port: 8501
+
+sparkMaster:
+  replicaCount: 1
+  image:
+    repository: bitnami/spark
+    tag: "3.4.1"
+  service:
+    type: ClusterIP
+    ports:
+      web:
+        port: 8080
+        targetPort: 8080
+      spark:
+        port: 7077
+        targetPort: 7077
+
+sparkWorker:
+  replicaCount: 1
+  image:
+    repository: bitnami/spark
+    tag: "3.4.1"
+  spark:
+    masterUrl: "spark://spark-master:7077"
+    workerMemory: "2G"
+    workerCores: 2
+
+postgresql:
+  image:
+    repository: postgres
+    tag: "15-alpine"
+  environment:
+    POSTGRES_DB: ecommerce_analytics
+    POSTGRES_USER: analytics_user
+    POSTGRES_PASSWORD: dev_password
+  service:
+    type: ClusterIP
+    port: 5432
+  persistence:
+    enabled: true
+    size: 1Gi
+
+redis:
+  image:
+    repository: redis
+    tag: "7-alpine"
+  service:
+    type: ClusterIP
+    port: 6379
+  persistence:
+    enabled: true
+    size: 1Gi
+
+minio:
+  image:
+    repository: minio/minio
+    tag: "latest"
+  environment:
+    MINIO_ROOT_USER: minioadmin
+    MINIO_ROOT_PASSWORD: minioadmin
+  service:
+    type: ClusterIP
+    port: 9000
+    consolePort: 9001
+  persistence:
+    enabled: true
+    size: 10Gi
+
+kafka:
+  image:
+    repository: confluentinc/cp-kafka
+    tag: "7.4.0"
+  kafka:
+    brokerId: 1
+    advertisedListeners: "PLAINTEXT://kafka:9092"
+    offsetsTopicReplicationFactor: 1
+    groupInitialRebalanceDelayMs: 0
+    jmxPort: 9997
+  service:
+    type: ClusterIP
+    port: 9092
+  persistence:
+    enabled: true
+    size: 10Gi
+
+zookeeper:
+  image:
+    repository: confluentinc/cp-zookeeper
+    tag: "7.4.0"
+  clientPort: 2181
+  tickTime: 2000
+  persistence:
+    enabled: true
+    dataSize: 1Gi
+    logSize: 1Gi


### PR DESCRIPTION
This PR introduces Helm charts for deploying the E-Commerce Analytics Platform services to Kubernetes. It includes:

- A main Helm chart () that acts as a parent chart.
- Sub-charts for each service: , , , , , , , , , , , and .
- Each sub-chart contains , , and  for , , and  where applicable.
- Common helper templates are defined in .
- A  is included for the main chart with installation and configuration instructions.

This work is part of Task 5.1.2.
