### PR TITLE
Fix streaming consumer CLI Spark session parameter mismatch

### DIFF
--- a/src/streaming/consumer_cli.py
+++ b/src/streaming/consumer_cli.py
@@ -69,8 +69,7 @@ def cli(ctx, kafka_servers, checkpoint_dir, max_consumers, spark_master, log_lev
     spark = create_spark_session(
         app_name="StreamingConsumerCLI",
         master=spark_master,
-        enable_hive_support=False,
-        additional_configs={
+        config={
             "spark.sql.streaming.checkpointLocation": checkpoint_dir,
             "spark.sql.streaming.kafka.consumer.pollTimeoutMs": "512",
             "spark.serializer": "org.apache.spark.serializer.KryoSerializer",


### PR DESCRIPTION
## Summary
Fixes TypeError in streaming consumer CLI caused by parameter mismatch in create_spark_session() function call.

## Problem
The `consumer_cli.py` was calling `create_spark_session()` with parameters that don't match the function signature:
- Called with: `enable_hive_support=False`, `additional_configs={...}`
- Function expects: `app_name`, `master`, `config`

## Solution
- ✅ Remove unsupported `enable_hive_support` parameter
- ✅ Rename `additional_configs` to `config` to match function signature
- ✅ Maintain same Spark configuration for streaming functionality

## Error Resolved
```
TypeError: create_spark_session() got an unexpected keyword argument 'enable_hive_support'
```

## Test Plan
- [x] Verify CLI module imports successfully
- [x] Verify `--help` command works
- [x] Verify no other instances of this pattern in codebase

🤖 Generated with [Claude Code](https://claude.ai/code)